### PR TITLE
Добавление обфускации для связанных между собой телефоном

### DIFF
--- a/src/pg_stage/mutator.py
+++ b/src/pg_stage/mutator.py
@@ -1,4 +1,5 @@
 import random
+import re
 from typing import Any, List
 
 from faker import Faker
@@ -19,6 +20,7 @@ class Mutator:
     max_value_serial = 2147483647
     min_value_bigserial = 1
     max_value_bigserial = 9223372036854775807
+    redacted_phone_pattern = r'[^\d]'
 
     def __init__(self, locale: str = 'en_US') -> None:
         """
@@ -459,3 +461,20 @@ class Mutator:
             return str(self._faker.unique.random_int(min=min_value, max=max_value))
 
         return str(self._faker.random_int(min=min_value, max=max_value))
+
+    def mutation_dependent_phone(self, obfuscated_original_number=None, **kwargs: Any) -> str:
+        if obfuscated_original_number:
+            return re.sub(self.redacted_phone_pattern, '', obfuscated_original_number)
+        return self.mutation_phone_number(**kwargs)
+
+    def mutation_subordinate_phone(self, obfuscated_redacted_number=None, **kwargs: Any) -> str:
+        if obfuscated_redacted_number:
+            return "{}({}){}-{}-{}".format(
+                obfuscated_redacted_number[0],
+                obfuscated_redacted_number[1:4],
+                obfuscated_redacted_number[4:7],
+                obfuscated_redacted_number[7:9],
+                obfuscated_redacted_number[9:],
+            )
+        return self.mutation_phone_number(**kwargs)
+

--- a/src/pg_stage/mutator.py
+++ b/src/pg_stage/mutator.py
@@ -469,12 +469,9 @@ class Mutator:
 
     def mutation_subordinate_phone(self, obfuscated_redacted_number=None, **kwargs: Any) -> str:
         if obfuscated_redacted_number:
-            return "{}({}){}-{}-{}".format(
-                obfuscated_redacted_number[0],
-                obfuscated_redacted_number[1:4],
-                obfuscated_redacted_number[4:7],
-                obfuscated_redacted_number[7:9],
-                obfuscated_redacted_number[9:],
-            )
+            phone = kwargs['format']
+            number_of_digits_in_mask = len(re.findall(r'\b\d+\b', phone))
+            for number in obfuscated_redacted_number[number_of_digits_in_mask:]:
+                phone = phone.replace('#', number, 1)
+            return phone
         return self.mutation_phone_number(**kwargs)
-

--- a/src/pg_stage/obfuscator.py
+++ b/src/pg_stage/obfuscator.py
@@ -181,6 +181,7 @@ class Obfuscator:
                 mutation_kwargs = mutation_for_column['mutation_kwargs']
                 mutation_relations = mutation_for_column['mutation_relations']
                 mutation_conditions = mutation_for_column['mutation_conditions']
+                mutation_name = mutation_for_column['mutation_name']
                 if not self._checking_conditions(conditions=mutation_conditions, table_values=table_values):
                     if mutation_index + 1 == len_mutations_for_column:
                         result.append(table_values[column_index])
@@ -204,6 +205,10 @@ class Obfuscator:
                         continue
 
                     new_value = self._relation_values.get(relation_fk)
+
+                    if mutation_name.startswith(('dependent', 'subordinate')):
+                        new_value = mutation_func(new_value)
+
                     if new_value is None:
                         raise ValueError('Invalid relation fk!')
 

--- a/src/pg_stage/obfuscator.py
+++ b/src/pg_stage/obfuscator.py
@@ -207,7 +207,7 @@ class Obfuscator:
                     new_value = self._relation_values.get(relation_fk)
 
                     if mutation_name.startswith(('dependent', 'subordinate')):
-                        new_value = mutation_func(new_value)
+                        new_value = mutation_func(new_value, **mutation_kwargs)
 
                     if new_value is None:
                         raise ValueError('Invalid relation fk!')

--- a/tests/sql/example_dump.sql
+++ b/tests/sql/example_dump.sql
@@ -258,7 +258,7 @@ COMMENT ON COLUMN auth_users.last_name IS 'anon: [{"mutation_name": "last_name"}
 -- Name: COLUMN auth_users.phone; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN auth_users.phone IS 'anon: [{"mutation_name": "subordinate_phone", "relations": [{"table_name": "auth_user_replica", "column_name": "phone", "from_column_name": "id", "to_column_name": "uuid"}], "mutation_kwargs": {"format": "7(9##)###-##-##"}}]';
+COMMENT ON COLUMN auth_users.phone IS 'anon: [{"mutation_name": "subordinate_phone", "relations": [{"table_name": "auth_user_replica", "column_name": "phone", "from_column_name": "id", "to_column_name": "uuid"}], "mutation_kwargs": {"format": "7 (9##) ### - ## - ##"}}]';
 
 
 --

--- a/tests/sql/example_dump.sql
+++ b/tests/sql/example_dump.sql
@@ -173,6 +173,11 @@ ALTER TABLE auth_user_replica OWNER TO postgres;
 
 COMMENT ON COLUMN auth_user_replica.email IS 'anon: [{"mutation_name": "email", "relations": [{"table_name": "auth_users", "column_name": "email", "from_column_name": "uuid", "to_column_name": "id"}]}]';
 
+--
+-- Name: COLUMN auth_users.phone; Type: COMMENT; Schema: public; Owner: postgres
+--
+
+COMMENT ON COLUMN auth_user_replica.phone IS 'anon: [{"mutation_name": "dependent_phone", "relations": [{"table_name": "auth_users", "column_name": "phone", "from_column_name": "uuid", "to_column_name": "id"}], "mutation_kwargs": {"format": "79#########"}}]';
 
 COPY auth_user_replica (uuid, email, crypted_password, password_salt, persistence_token, created_at, updated_at, active, first_name, last_name, agency_id, phone, perishable_token, extension, commissioned, region, division, location, last_request_at) FROM stdin;
 07750c56-fb37-46e1-b7b6-da530704c056	cj@example.com	400$8$4c$c11df6facaefc6bc$93a657fb3c6e4cd1fd3255d3bd1edd18ffc4a8092e2616b9e5ca7954b2c52504	v8BMktHnOeokEBTy6As	86a97ff982e87ed5af7d90ab2ce31d4e89a3af3e6a0490b067bb8213aea7a4ee0eeafae1d8fe3c6f990aead095092fcf852004b18e484ef22569aebf64c3747f	2016-06-03 18:23:06.25685	2016-06-03 18:23:06.25685	t	C.J.	Cregg	\N	1231231234	hw1rFSX7yJBz65lDVzYi	\N	f	\N	\N	\N	\N
@@ -253,7 +258,7 @@ COMMENT ON COLUMN auth_users.last_name IS 'anon: [{"mutation_name": "last_name"}
 -- Name: COLUMN auth_users.phone; Type: COMMENT; Schema: public; Owner: postgres
 --
 
-COMMENT ON COLUMN auth_users.phone IS 'anon: [{"mutation_name": "phone_number", "mutation_kwargs": {"format": "79#########"}}]';
+COMMENT ON COLUMN auth_users.phone IS 'anon: [{"mutation_name": "subordinate_phone", "relations": [{"table_name": "auth_user_replica", "column_name": "phone", "from_column_name": "id", "to_column_name": "uuid"}], "mutation_kwargs": {"format": "7(9##)###-##-##"}}]';
 
 
 --


### PR DESCRIPTION
https://github.com/froOzzy/pg_stage/issues/37

Дополнена реализация 'relations' для того, чтобы сохранить построчную обработку данных: в обфускаторе передается уже обфусцированное поле, если оно есть, а мутатор в зависимости от входных условий (всего 4 случая) обрабатывает поле.

_Для корректной работы маска телефона должна иметь **цифры** только до или после **#**_ 

_Например: `7 (9##) ### - ## - 99`, `7 (9##) ### - ## - ##`, `# (###) ### - ## - 99` -- можно, а `# (###) ##8 - 56 - ## ` -- нельзя_