### PR TITLE
Добавлена возможность обфускации uuid на основе значения другой колонки

### DIFF
--- a/src/pg_stage/mutator.py
+++ b/src/pg_stage/mutator.py
@@ -524,13 +524,18 @@ class Mutator:
         текущей даты и переданного uuid namespace.
 
         :param kwargs:
-            source_value: Значение из колонки, например номер телефона.
+            source_column: Название колонки, значение которой хотим использовать.
             namespace: Uuid namespace.
         :return: Строка uuid5.
         """
-        source_value: str = kwargs.get('source_value')
+        source_column: str = kwargs.get('source_column')
+        if not source_column:
+            raise ValueError('Argument "source_column" not found')
+
+        obfuscated_values: dict = kwargs.get('obfuscated_values')
+        source_value: str = obfuscated_values.get(source_column)
         if not source_value:
-            raise ValueError('Argument "source_value" not found')
+            raise ValueError('Value of "source_column" not found')
 
         uuid_namespace = kwargs.get('namespace')
         if uuid_namespace is None:

--- a/src/pg_stage/mutator.py
+++ b/src/pg_stage/mutator.py
@@ -517,8 +517,7 @@ class Mutator:
         """
         return str(uuid.uuid4())
 
-    @staticmethod
-    def mutation_uuid5_by_source_value(**kwargs: Any) -> str:
+    def mutation_uuid5_by_source_value(self, **kwargs: Any) -> str:
         """
         Метод для формирования uuid5 с использованием значения из указанной колонки,
         текущей даты и переданного uuid namespace.
@@ -532,20 +531,19 @@ class Mutator:
         if not source_column:
             raise ValueError('Argument "source_column" not found')
 
-        obfuscated_values: dict = kwargs.get('obfuscated_values')
+        obfuscated_values: dict[str, Any] = kwargs.get('obfuscated_values', {})
         source_value: str = obfuscated_values.get(source_column)
         if not source_value:
             raise ValueError('Value of "source_column" not found')
 
-        uuid_namespace = kwargs.get('namespace')
+        uuid_namespace: str = kwargs.get('namespace')
         if uuid_namespace is None:
             raise ValueError('Argument "namespace" not found')
 
-        if not isinstance(uuid_namespace, uuid.UUID):
-            try:
-                uuid_namespace = uuid.UUID(str(uuid_namespace))
-            except Exception as e:
-                raise ValueError('Invalid uuid namespace given') from e
+        try:
+            uuid_namespace: uuid.UUID = uuid.UUID(uuid_namespace)
+        except Exception as e:
+            raise ValueError('Invalid uuid namespace given') from e
 
-        date_today = datetime.date.today()
+        date_today: datetime.date = self._now.date()
         return str(uuid.uuid5(uuid_namespace, f'{source_value}-{date_today}'))

--- a/src/pg_stage/mutator.py
+++ b/src/pg_stage/mutator.py
@@ -1,9 +1,9 @@
-import random
 import datetime
+import random
 import uuid
 from typing import Any, Callable, List
 
-from mimesis import Person, Address, Datetime, Internet, Numbers
+from mimesis import Address, Datetime, Internet, Numbers, Person
 from mimesis.builtins import RussiaSpecProvider
 
 
@@ -516,3 +516,31 @@ class Mutator:
         :return: строка uuid4
         """
         return str(uuid.uuid4())
+
+    @staticmethod
+    def mutation_uuid5_by_source_value(**kwargs: Any) -> str:
+        """
+        Метод для формирования uuid5 с использованием значения из указанной колонки,
+        текущей даты и переданного uuid namespace.
+
+        :param kwargs:
+            source_value: Значение из колонки, например номер телефона.
+            namespace: Uuid namespace.
+        :return: Строка uuid5.
+        """
+        source_value: str = kwargs.get('source_value')
+        if not source_value:
+            raise ValueError('Argument "source_value" not found')
+
+        uuid_namespace = kwargs.get('namespace')
+        if uuid_namespace is None:
+            raise ValueError('Argument "namespace" not found')
+
+        if not isinstance(uuid_namespace, uuid.UUID):
+            try:
+                uuid_namespace = uuid.UUID(str(uuid_namespace))
+            except Exception as e:
+                raise ValueError('Invalid uuid namespace given') from e
+
+        date_today = datetime.date.today()
+        return str(uuid.uuid5(uuid_namespace, f'{source_value}-{date_today}'))

--- a/src/pg_stage/obfuscator.py
+++ b/src/pg_stage/obfuscator.py
@@ -126,7 +126,6 @@ class Obfuscator:
                     'mutation_kwargs': mutation_param.get('mutation_kwargs', {}),
                     'mutation_relations': mutation_param.get('relations', []),
                     'mutation_conditions': mutation_param.get('conditions', []),
-                    'mutation_source_column': mutation_param.get('source_column'),
                 },
             )
 

--- a/src/pg_stage/obfuscator.py
+++ b/src/pg_stage/obfuscator.py
@@ -155,14 +155,14 @@ class Obfuscator:
 
     def _sort_columns_by_source_column_exists(self, table_mutations_by_column: dict) -> list:
         """
-        Метод для сортировки столбцов на основе наличия параметра `source_column` в мутации.
+        Метод для сортировки столбцов на основе наличия параметра `source_column` в аргументах мутации.
         :return: Список с верным порядком прохождения столбцов
         """
         independent_columns = []
         dependent_columns = []
         for column_name in self._enumerate_table_columns:
             mutations_for_column = table_mutations_by_column.get(column_name)
-            if mutations_for_column and mutations_for_column[0]['mutation_source_column']:
+            if mutations_for_column and 'source_column' in mutations_for_column[0].get('mutation_kwargs', {}):
                 dependent_columns.append(column_name)
                 continue
             independent_columns.append(column_name)
@@ -201,7 +201,6 @@ class Obfuscator:
                 mutation_kwargs = mutation_for_column['mutation_kwargs']
                 mutation_relations = mutation_for_column['mutation_relations']
                 mutation_conditions = mutation_for_column['mutation_conditions']
-                mutation_source_column = mutation_for_column['mutation_source_column']
                 if not self._checking_conditions(conditions=mutation_conditions, table_values=table_values):
                     if mutation_index + 1 == len_mutations_for_column:
                         obfuscated_values[column_name] = table_values[column_index]
@@ -209,11 +208,8 @@ class Obfuscator:
 
                     continue
 
-                if mutation_source_column:
-                    source_index = self._enumerate_table_columns.get(mutation_source_column)
-                    if source_index is None:
-                        raise ValueError(f'Column {mutation_source_column} not found in table {self._table_name}')
-                    mutation_kwargs['source_value'] = obfuscated_values[mutation_source_column]
+                if 'source_column' in mutation_kwargs:
+                    mutation_kwargs['obfuscated_values'] = obfuscated_values
 
                 if not mutation_relations:
                     is_obfuscated = True
@@ -251,7 +247,7 @@ class Obfuscator:
                 obfuscated_values[column_name] = new_value
                 is_obfuscated = True
 
-        sorted_result: list[str | None] = [None] * len(self._enumerate_table_columns)
+        sorted_result: list[Optional[str]] = [None] * len(self._enumerate_table_columns)
         for column_name, column_index in self._enumerate_table_columns.items():
             sorted_result[column_index] = obfuscated_values[column_name]
 

--- a/src/pg_stage/obfuscator.py
+++ b/src/pg_stage/obfuscator.py
@@ -1,8 +1,8 @@
+import json
 import re
 import sys
-import json
 from collections import defaultdict
-from typing import Optional, List, Set, Dict
+from typing import Dict, List, Optional, Set
 from uuid import uuid4
 
 from pg_stage.mutator import Mutator
@@ -188,6 +188,13 @@ class Obfuscator:
                         break
 
                     continue
+
+                if 'source_column' in mutation_kwargs:
+                    source_column = mutation_kwargs['source_column']
+                    source_index = self._enumerate_table_columns.get(source_column)
+                    if source_index is None:
+                        raise ValueError(f'Column {source_column} not found in table {self._table_name}')
+                    mutation_kwargs['source_value'] = table_values[source_index]
 
                 if not mutation_relations:
                     is_obfuscated = True

--- a/src/pg_stage/typing.py
+++ b/src/pg_stage/typing.py
@@ -41,7 +41,6 @@ class MapTablesValueType(TypedDict):
     mutation_kwargs: Dict[str, Any]
     mutation_relations: RelationTypeMany
     mutation_conditions: ConditionTypeMany
-    mutation_source_column: str
 
 
 MapTablesValueTypeMany = List[MapTablesValueType]

--- a/src/pg_stage/typing.py
+++ b/src/pg_stage/typing.py
@@ -41,6 +41,7 @@ class MapTablesValueType(TypedDict):
     mutation_kwargs: Dict[str, Any]
     mutation_relations: RelationTypeMany
     mutation_conditions: ConditionTypeMany
+    mutation_source_column: str
 
 
 MapTablesValueTypeMany = List[MapTablesValueType]

--- a/tests/sql/test_obfuscate_uuid_by_source_value.sql
+++ b/tests/sql/test_obfuscate_uuid_by_source_value.sql
@@ -1,0 +1,7 @@
+COMMENT ON COLUMN table_1.username IS 'anon: [{"mutation_name": "phone_number", "mutation_kwargs": {"mask": "791########", "unique": true}, "conditions": [{"column_name": "username", "operation": "by_pattern", "value": "^7[0-9]{10}$"}]}]';
+COMMENT ON COLUMN table_1.uuid IS 'anon: [{"mutation_name": "uuid5_by_source_value", "source_column": "username", "mutation_kwargs": {"namespace": "6ba7b810-9dad-11d1-80b4-00c04fd430c8"}}]';
+COPY table_1 (uuid, username, last_name) FROM stdin;
+20f654fe-b27d-4051-9fd4-000000000001	79999999999	111n
+20f654fe-b27d-4051-9fd4-000000000002	79888888888	222n
+20f654fe-b27d-4051-9fd4-000000000003	79777777777	333n
+\.

--- a/tests/sql/test_obfuscate_uuid_by_source_value.sql
+++ b/tests/sql/test_obfuscate_uuid_by_source_value.sql
@@ -1,5 +1,5 @@
 COMMENT ON COLUMN table_1.username IS 'anon: [{"mutation_name": "phone_number", "mutation_kwargs": {"mask": "791########", "unique": true}, "conditions": [{"column_name": "username", "operation": "by_pattern", "value": "^7[0-9]{10}$"}]}]';
-COMMENT ON COLUMN table_1.uuid IS 'anon: [{"mutation_name": "uuid5_by_source_value", "source_column": "username", "mutation_kwargs": {"namespace": "6ba7b810-9dad-11d1-80b4-00c04fd430c8"}}]';
+COMMENT ON COLUMN table_1.uuid IS 'anon: [{"mutation_name": "uuid5_by_source_value", "mutation_kwargs": {"source_column": "username", "namespace": "6ba7b810-9dad-11d1-80b4-00c04fd430c8"}}]';
 COPY table_1 (uuid, username, last_name) FROM stdin;
 20f654fe-b27d-4051-9fd4-000000000001	79999999999	111n
 20f654fe-b27d-4051-9fd4-000000000002	79888888888	222n


### PR DESCRIPTION
Проблема:
два несвязанных сервера с базами  
в обоих базах лежит колонка, которая после обфускации должна быть одинаковой на обоих серверах  

те нужно из одних и тех же данных генерировать данные для другой колонки  

Решение:
генерировать uuid на основе другой колонки, чтобы на двух серверах uuid был одинаковым при одинаковом значение исходной колонки  

Что сделал:  
для комментов вида:
```SQL
COMMENT ON COLUMN uuid IS 'anon: [{"mutation_name": "uuid5_by_source_value", "mutation_kwargs": {"source_column": "username", "namespace": "73556080-0000-0000-0000-735560800000"}}]';
```
будет сгенерирован uuid на основе значения колонки `username` текущей строки + переданного `uuid namespace` и текущей даты (чтобы изо дня в день значения менялись) (одно из условий)  


