### PR TITLE
Исправление OOM при pg_restore после обфускации

### DIFF
--- a/src/pg_stage/custom.py
+++ b/src/pg_stage/custom.py
@@ -798,12 +798,11 @@ class DataBlockProcessor:
         :param dump_id: ID записи дампа
         :param chunks: список чанков для записи
         """
-        total_size = sum(len(chunk) for chunk in chunks)
         output_stream.write(BlockType.DATA)
         output_stream.write(self.dio.write_int(dump_id))
-        output_stream.write(self.dio.write_int(total_size))
 
         for chunk in chunks:
+            output_stream.write(self.dio.write_int(len(chunk)))
             output_stream.write(chunk)
 
         output_stream.flush()


### PR DESCRIPTION
Во время выполнения pg_restore после обфускации возникала ошибка Out of Memory.
Причина заключалась в том, что в текущей реализации все читаемые чанки данных записывались в один общий буфер, что приводило к чрезмерному росту потребления памяти.