### PR TITLE
Мутатор для jsonb полей

### DIFF
--- a/src/pg_stage/mutator.py
+++ b/src/pg_stage/mutator.py
@@ -1,6 +1,7 @@
 import datetime
 import hashlib
 import hmac
+import json
 import random
 import uuid
 from os import environ
@@ -609,3 +610,46 @@ class Mutator:
         rng.shuffle(digits_list)
 
         return f'{not_obfuscated_digits}{"".join(digits_list)}'
+
+    def mutation_json_update(self, **kwargs: Any) -> str:
+        """
+        Метод для частичного обновления JSON-поля.
+        :param kwargs:
+            current_value - текущее значение JSON-поля из БД
+            <json_key> - словарь с ``mutation_name`` и дополнительными параметрами мутации
+        :return: строка с обновлённым JSON
+        """
+        current_value: Optional[str] = kwargs.get('current_value')
+        if not current_value or current_value == '\\N':
+            return current_value or '\\N'
+
+        try:
+            data: dict = json.loads(current_value)
+        except (json.JSONDecodeError, ValueError):
+            msg = f'Invalid JSON value: {current_value!r}'
+            raise ValueError(msg)
+
+        # Все kwargs кроме 'current_value' трактуются как ключи JSON-объекта
+        _system_keys = {'current_value'}
+        key_mutations: dict = {k: v for k, v in kwargs.items() if k not in _system_keys}
+
+        for key, key_mutation in key_mutations.items():
+            mutation_name: str = key_mutation.get('mutation_name', '')
+            if not mutation_name:
+                msg = f'mutation_name not specified for key "{key}"'
+                raise ValueError(msg)
+
+            if mutation_name == 'delete':
+                data.pop(key, None)
+                continue
+
+            mutation_func = getattr(self, f'mutation_{mutation_name}', None)
+            if not mutation_func:
+                msg = f'Not found mutation "{mutation_name}" for key "{key}".'
+                raise ValueError(msg)
+
+            # Передаём все параметры из описания мутации ключа, кроме mutation_name
+            call_kwargs = {k: v for k, v in key_mutation.items() if k != 'mutation_name'}
+            data[key] = mutation_func(**call_kwargs)
+
+        return json.dumps(data, ensure_ascii=False)

--- a/src/pg_stage/mutator.py
+++ b/src/pg_stage/mutator.py
@@ -620,20 +620,16 @@ class Mutator:
         :return: строка с обновлённым JSON
         """
         current_value: Optional[str] = kwargs.get('current_value')
-        if current_value is None:
+        if current_value in (None, '\\N'):
             return '\\N'
-        if current_value == '\\N':
-            return current_value
 
         try:
             data: dict = json.loads(current_value)
         except (json.JSONDecodeError, ValueError) as error:
-            msg = f'Invalid JSON value'
-            raise ValueError(msg) from error
+            raise ValueError('Invalid JSON value') from error
 
         if not isinstance(data, dict):
-            msg = f'json_update expects a JSON object'
-            raise ValueError(msg)
+            raise ValueError('json_update expects a dict object')
 
         # Все kwargs кроме служебных параметров трактуются как ключи JSON-объекта
         _system_keys = {'current_value', 'obfuscated_values'}
@@ -641,15 +637,15 @@ class Mutator:
 
         for key, key_mutation in key_mutations.items():
             if not isinstance(key_mutation, dict):
-                msg = f'The value for key "{key}" must be an object (dict), but got {type(key_mutation).__name__}'
-                raise ValueError(msg)
+                raise ValueError(
+                    f'The value for key "{key}" must be an object (dict), but got {type(key_mutation).__name__}'
+                )
 
             mutation_name: str = key_mutation.get('mutation_name', '')
             original_value = data.get(key)
 
             if not mutation_name:
-                msg = f'mutation_name not specified for key "{key}"'
-                raise ValueError(msg)
+                raise ValueError(f'mutation_name not specified for key "{key}"')
 
             if mutation_name == 'delete':
                 data.pop(key, None)
@@ -661,8 +657,7 @@ class Mutator:
 
             mutation_func = getattr(self, f'mutation_{mutation_name}', None)
             if not mutation_func:
-                msg = f'Not found mutation "{mutation_name}"'
-                raise ValueError(msg)
+                raise ValueError(f'Not found mutation "{mutation_name}"')
 
             # Передаём все параметры из описания мутации ключа, кроме mutation_name
             call_kwargs = {k: v for k, v in key_mutation.items() if k != 'mutation_name'}

--- a/src/pg_stage/mutator.py
+++ b/src/pg_stage/mutator.py
@@ -643,6 +643,10 @@ class Mutator:
                 data.pop(key, None)
                 continue
 
+            if mutation_name == 'null':
+                data[key] = None
+                continue
+
             mutation_func = getattr(self, f'mutation_{mutation_name}', None)
             if not mutation_func:
                 msg = f'Not found mutation "{mutation_name}" for key "{key}".'

--- a/src/pg_stage/mutator.py
+++ b/src/pg_stage/mutator.py
@@ -620,17 +620,19 @@ class Mutator:
         :return: строка с обновлённым JSON
         """
         current_value: Optional[str] = kwargs.get('current_value')
-        if not current_value or current_value == '\\N':
-            return current_value or '\\N'
+        if current_value is None:
+            return '\\N'
+        if current_value == '\\N':
+            return current_value
 
         try:
             data: dict = json.loads(current_value)
         except (json.JSONDecodeError, ValueError) as error:
-            msg = f'Invalid JSON value: {current_value!r}'
+            msg = f'Invalid JSON value'
             raise ValueError(msg) from error
 
         if not isinstance(data, dict):
-            msg = f'json_update expects a JSON object: {current_value!r}'
+            msg = f'json_update expects a JSON object'
             raise ValueError(msg)
 
         # Все kwargs кроме служебных параметров трактуются как ключи JSON-объекта

--- a/src/pg_stage/mutator.py
+++ b/src/pg_stage/mutator.py
@@ -661,7 +661,7 @@ class Mutator:
 
             mutation_func = getattr(self, f'mutation_{mutation_name}', None)
             if not mutation_func:
-                msg = f'Not found mutation "{mutation_name}" for key "{key}".'
+                msg = f'Not found mutation "{mutation_name}"'
                 raise ValueError(msg)
 
             # Передаём все параметры из описания мутации ключа, кроме mutation_name
@@ -678,10 +678,10 @@ class Mutator:
 
             new_value = mutation_func(**call_kwargs)
 
-            # сохраняем исходный тип JSON-значения
-            if original_value is not None:
+            # сохраняем исходный тип числового значения
+            if isinstance(original_value, int):
                 try:
-                    new_value = type(original_value)(new_value)
+                    new_value = int(new_value)
                 except (TypeError, ValueError):
                     pass
 

--- a/src/pg_stage/mutator.py
+++ b/src/pg_stage/mutator.py
@@ -645,6 +645,7 @@ class Mutator:
                 raise ValueError(msg)
 
             mutation_name: str = key_mutation.get('mutation_name', '')
+            original_value = data.get(key)
 
             if not mutation_name:
                 msg = f'mutation_name not specified for key "{key}"'
@@ -665,10 +666,25 @@ class Mutator:
 
             # Передаём все параметры из описания мутации ключа, кроме mutation_name
             call_kwargs = {k: v for k, v in key_mutation.items() if k != 'mutation_name'}
-            call_kwargs.setdefault('current_value', data.get(key))
+
+            normalized_current_value = original_value
+            if original_value is not None and not isinstance(original_value, str):
+                normalized_current_value = json.dumps(original_value, ensure_ascii=False)
+
+            call_kwargs.setdefault('current_value', normalized_current_value)
+
             if 'obfuscated_values' in kwargs:  # пробрасываем только если есть, не навязываем
                 call_kwargs.setdefault('obfuscated_values', kwargs['obfuscated_values'])
 
-            data[key] = mutation_func(**call_kwargs)
+            new_value = mutation_func(**call_kwargs)
+
+            # сохраняем исходный тип JSON-значения
+            if original_value is not None:
+                try:
+                    new_value = type(original_value)(new_value)
+                except (TypeError, ValueError):
+                    pass
+
+            data[key] = new_value
 
         return json.dumps(data, ensure_ascii=False)

--- a/src/pg_stage/mutator.py
+++ b/src/pg_stage/mutator.py
@@ -2,6 +2,7 @@ import datetime
 import hashlib
 import hmac
 import json
+import logging
 import random
 import uuid
 from os import environ
@@ -9,6 +10,14 @@ from typing import Any, Callable, List, Optional
 
 from mimesis import Address, Datetime, Internet, Numbers, Person
 from mimesis.builtins import RussiaSpecProvider
+
+from pg_stage.utils import (
+    apply_mutations_to_json_value,
+    get_mutation_func as shared_get_mutation_func,
+    run_mutation as shared_run_mutation,
+)
+
+logger = logging.getLogger(__name__)
 
 
 class Mutator:
@@ -107,6 +116,38 @@ class Mutator:
                 a = p
             code[i] = a
         return code.decode()
+
+    def get_mutation_func(self, *, mutation_name: str) -> Callable[..., Any]:
+        """
+        Метод для получения callable мутации по имени.
+        :param mutation_name: название мутации (без префикса 'mutation_')
+        :return: callable функция мутации
+        """
+        return shared_get_mutation_func(mutation_owner=self, mutation_name=mutation_name)
+
+    def run_mutation(
+        self,
+        *,
+        mutation_name: str,
+        mutation_kwargs: Optional[dict[str, Any]] = None,
+        current_value: Any = None,
+        obfuscated_values: Optional[dict[str, Any]] = None,
+    ) -> Any:
+        """
+        Метод для выполнения мутации с безопасным merge runtime-контекста.
+        :param mutation_name: название мутации (без префикса 'mutation_')
+        :param mutation_kwargs: параметры мутации, опционально
+        :param current_value: текущее значение поля, опционально
+        :param obfuscated_values: словарь обфусцированных значений для cross-column операций, опционально
+        :return: результат применения мутации
+        """
+        return shared_run_mutation(
+            mutation_owner=self,
+            mutation_name=mutation_name,
+            mutation_kwargs=mutation_kwargs,
+            current_value=current_value,
+            obfuscated_values=obfuscated_values,
+        )
 
     def mutation_email(self, **kwargs: bool) -> str:
         """
@@ -613,73 +654,95 @@ class Mutator:
 
     def mutation_json_update(self, **kwargs: Any) -> str:
         """
-        Метод для частичного обновления JSON-поля.
+        Метод для частичного обновления JSON-поля по ключам.
         :param kwargs:
             current_value - текущее значение JSON-поля из БД
-            <json_key> - словарь с ``mutation_name`` и дополнительными параметрами мутации
+            mutations_by_key - словарь вида:
+                {
+                    "json_key": [
+                        {
+                            "mutation_name": "mutation", 
+                            "mutation_kwargs"?: {"value": "x"}
+                        },
+                    ]
+                }
+            Каждая мутация в списке применяется последовательно.
         :return: строка с обновлённым JSON
         """
         current_value: Optional[str] = kwargs.get('current_value')
-        if current_value in (None, '\\N'):
-            return '\\N'
+        if current_value == '\\N':
+            return current_value
 
         try:
-            data: dict = json.loads(current_value)
+            data: dict[str, Any] = json.loads(current_value)
         except (json.JSONDecodeError, ValueError) as error:
             raise ValueError('Invalid JSON value') from error
 
         if not isinstance(data, dict):
-            raise ValueError('json_update expects a dict object')
+            logger.warning('json_update expects a dict object after JSON parsing')
+            return current_value
 
-        # Все kwargs кроме служебных параметров трактуются как ключи JSON-объекта
-        _system_keys = {'current_value', 'obfuscated_values'}
-        key_mutations: dict = {k: v for k, v in kwargs.items() if k not in _system_keys}
+        mutations_by_key: Any = kwargs.get('mutations_by_key')
+        if mutations_by_key is None:
+            raise ValueError('mutations_by_key is required')
 
-        for key, key_mutation in key_mutations.items():
-            if not isinstance(key_mutation, dict):
-                raise ValueError(
-                    f'The value for key "{key}" must be an object (dict), but got {type(key_mutation).__name__}'
-                )
+        if not isinstance(mutations_by_key, dict):
+            raise ValueError('mutations_by_key must be an object (dict)')
 
-            mutation_name: str = key_mutation.get('mutation_name', '')
-            original_value = data.get(key)
+        obfuscated_values = kwargs.get('obfuscated_values')
+        seen_keys: set[str] = set()
 
-            if not mutation_name:
-                raise ValueError(f'mutation_name not specified for key "{key}"')
+        def walk_json(node: Any) -> Any:
+            if isinstance(node, dict):
+                updated_node: dict[str, Any] = {}
+                for key, value in node.items():
+                    nested_value = walk_json(value)
+                    key_mutations = mutations_by_key.get(key)
+                    if not key_mutations:
+                        updated_node[key] = nested_value
+                        continue
 
-            if mutation_name == 'delete':
-                data.pop(key, None)
+                    if not isinstance(key_mutations, list):
+                        raise ValueError(f'The value for key "{key}" must be a list of mutators')
+
+                    seen_keys.add(key)
+                    is_deleted, new_value = apply_mutations_to_json_value(
+                        mutation_owner=self,
+                        value=nested_value,
+                        key_mutations=key_mutations,
+                        obfuscated_values=obfuscated_values,
+                    )
+                    if is_deleted:
+                        continue
+
+                    updated_node[key] = new_value
+
+                return updated_node
+
+            if isinstance(node, list):
+                return [walk_json(item) for item in node]
+
+            return node
+
+        updated_data = walk_json(data)
+
+        # Если ключ не найден в JSON, применяем мутации на root-уровне (как и раньше ключ добавлялся).
+        for key, key_mutations in mutations_by_key.items():
+            if key in seen_keys:
                 continue
 
-            if mutation_name == 'null':
-                data[key] = None
+            if not isinstance(key_mutations, list):
+                raise ValueError(f'The value for key "{key}" must be a list of mutators')
+
+            is_deleted, new_value = apply_mutations_to_json_value(
+                mutation_owner=self,
+                value=None,
+                key_mutations=key_mutations,
+                obfuscated_values=obfuscated_values,
+            )
+            if is_deleted:
                 continue
 
-            mutation_func = getattr(self, f'mutation_{mutation_name}', None)
-            if not mutation_func:
-                raise ValueError(f'Not found mutation "{mutation_name}"')
+            updated_data[key] = new_value
 
-            # Передаём все параметры из описания мутации ключа, кроме mutation_name
-            call_kwargs = {k: v for k, v in key_mutation.items() if k != 'mutation_name'}
-
-            normalized_current_value = original_value
-            if original_value is not None and not isinstance(original_value, str):
-                normalized_current_value = json.dumps(original_value, ensure_ascii=False)
-
-            call_kwargs.setdefault('current_value', normalized_current_value)
-
-            if 'obfuscated_values' in kwargs:  # пробрасываем только если есть, не навязываем
-                call_kwargs.setdefault('obfuscated_values', kwargs['obfuscated_values'])
-
-            new_value = mutation_func(**call_kwargs)
-
-            # сохраняем исходный тип числового значения
-            if isinstance(original_value, int):
-                try:
-                    new_value = int(new_value)
-                except (TypeError, ValueError):
-                    pass
-
-            data[key] = new_value
-
-        return json.dumps(data, ensure_ascii=False)
+        return json.dumps(updated_data, ensure_ascii=False)

--- a/src/pg_stage/mutator.py
+++ b/src/pg_stage/mutator.py
@@ -633,15 +633,16 @@ class Mutator:
             msg = f'json_update expects a JSON object: {current_value!r}'
             raise ValueError(msg)
 
-        # Все kwargs кроме 'current_value' трактуются как ключи JSON-объекта
-        _system_keys = {'current_value'}
+        # Все kwargs кроме служебных параметров трактуются как ключи JSON-объекта
+        _system_keys = {'current_value', 'obfuscated_values'}
         key_mutations: dict = {k: v for k, v in kwargs.items() if k not in _system_keys}
 
         for key, key_mutation in key_mutations.items():
-            mutation_name: str = key_mutation.get('mutation_name', '')
             if not isinstance(key_mutation, dict):
                 msg = f'The value for key "{key}" must be an object (dict), but got {type(key_mutation).__name__}'
                 raise ValueError(msg)
+
+            mutation_name: str = key_mutation.get('mutation_name', '')
 
             if not mutation_name:
                 msg = f'mutation_name not specified for key "{key}"'

--- a/src/pg_stage/mutator.py
+++ b/src/pg_stage/mutator.py
@@ -625,8 +625,12 @@ class Mutator:
 
         try:
             data: dict = json.loads(current_value)
-        except (json.JSONDecodeError, ValueError):
+        except (json.JSONDecodeError, ValueError) as error:
             msg = f'Invalid JSON value: {current_value!r}'
+            raise ValueError(msg) from error
+
+        if not isinstance(data, dict):
+            msg = f'json_update expects a JSON object: {current_value!r}'
             raise ValueError(msg)
 
         # Все kwargs кроме 'current_value' трактуются как ключи JSON-объекта
@@ -635,6 +639,10 @@ class Mutator:
 
         for key, key_mutation in key_mutations.items():
             mutation_name: str = key_mutation.get('mutation_name', '')
+            if not isinstance(key_mutation, dict):
+                msg = f'The value for key "{key}" must be an object (dict), but got {type(key_mutation).__name__}'
+                raise ValueError(msg)
+
             if not mutation_name:
                 msg = f'mutation_name not specified for key "{key}"'
                 raise ValueError(msg)
@@ -654,6 +662,10 @@ class Mutator:
 
             # Передаём все параметры из описания мутации ключа, кроме mutation_name
             call_kwargs = {k: v for k, v in key_mutation.items() if k != 'mutation_name'}
+            call_kwargs.setdefault('current_value', data.get(key))
+            if 'obfuscated_values' in kwargs:  # пробрасываем только если есть, не навязываем
+                call_kwargs.setdefault('obfuscated_values', kwargs['obfuscated_values'])
+
             data[key] = mutation_func(**call_kwargs)
 
         return json.dumps(data, ensure_ascii=False)

--- a/src/pg_stage/obfuscators/plain.py
+++ b/src/pg_stage/obfuscators/plain.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 from pg_stage.mutator import Mutator
 from pg_stage.types import ConditionTypeMany, MapTablesValueTypeMany
+from pg_stage.utils import get_mutation_func, run_mutation
 
 
 class PlainObfuscator:
@@ -109,10 +110,7 @@ class PlainObfuscator:
 
         for mutation_param in mutations_params:
             mutation_name = mutation_param['mutation_name']
-            mutation_func = getattr(self._mutator, f'mutation_{mutation_name}', None)
-            if not mutation_func:
-                msg = f'Not found mutation {mutation_name}.'
-                raise ValueError(msg)
+            get_mutation_func(mutation_owner=self._mutator, mutation_name=mutation_name)
 
             try:
                 table_name, column_name = result.group(1).split('.')
@@ -124,7 +122,6 @@ class PlainObfuscator:
             self._map_tables[table_name][column_name].append(
                 {
                     'mutation_name': mutation_name,
-                    'mutation_func': mutation_func,
                     'mutation_kwargs': mutation_param.get('mutation_kwargs', {}),
                     'mutation_relations': mutation_param.get('relations', []),
                     'mutation_conditions': mutation_param.get('conditions', []),
@@ -198,13 +195,10 @@ class PlainObfuscator:
                 if is_obfuscated:
                     break
 
-                mutation_func = mutation_for_column['mutation_func']
+                mutation_name = mutation_for_column['mutation_name']
                 mutation_kwargs = mutation_for_column['mutation_kwargs']
                 mutation_relations = mutation_for_column['mutation_relations']
                 mutation_conditions = mutation_for_column['mutation_conditions']
-
-                # Сохранить текущее значение для обработки в Mutator
-                mutation_kwargs['current_value'] = table_values[column_index]
 
                 if not self._checking_conditions(conditions=mutation_conditions, table_values=table_values):
                     if mutation_index + 1 == len_mutations_for_column:
@@ -213,12 +207,19 @@ class PlainObfuscator:
 
                     continue
 
+                context_obfuscated_values = None
                 if 'source_column' in mutation_kwargs:
-                    mutation_kwargs['obfuscated_values'] = obfuscated_values
+                    context_obfuscated_values = obfuscated_values
 
                 if not mutation_relations:
                     is_obfuscated = True
-                    obfuscated_values[column_name] = mutation_func(**mutation_kwargs)
+                    obfuscated_values[column_name] = run_mutation(
+                        mutation_owner=self._mutator,
+                        mutation_name=mutation_name,
+                        mutation_kwargs=mutation_kwargs,
+                        current_value=table_values[column_index],
+                        obfuscated_values=context_obfuscated_values,
+                    )
                     continue
 
                 new_value = None
@@ -240,7 +241,13 @@ class PlainObfuscator:
 
                 if new_value is None:
                     relation_fk = str(uuid4())
-                    new_value = mutation_func(**mutation_kwargs)
+                    new_value = run_mutation(
+                        mutation_owner=self._mutator,
+                        mutation_name=mutation_name,
+                        mutation_kwargs=mutation_kwargs,
+                        current_value=table_values[column_index],
+                        obfuscated_values=context_obfuscated_values,
+                    )
                     for mutation_relation in mutation_relations:
                         key_table = f'{self._table_name}:{column_name}'
                         from_column_name = mutation_relation['from_column_name']

--- a/src/pg_stage/types.py
+++ b/src/pg_stage/types.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Callable, Dict, List
+from typing import Any, Dict, List
 
 from typing_extensions import TypedDict
 
@@ -37,7 +37,6 @@ class MapTablesValueType(TypedDict):
     """Описание типа значения карты таблиц"""
 
     mutation_name: str
-    mutation_func: Callable[..., str]
     mutation_kwargs: Dict[str, Any]
     mutation_relations: RelationTypeMany
     mutation_conditions: ConditionTypeMany

--- a/src/pg_stage/utils.py
+++ b/src/pg_stage/utils.py
@@ -1,0 +1,140 @@
+import json
+from typing import Any, Callable, Optional
+
+
+def get_mutation_func(*, mutation_owner: Any, mutation_name: str) -> Callable[..., Any]:
+    """
+    Метод для получения callable мутации по имени из объекта
+    :param mutation_owner: объект, содержащий методы mutation_<name>
+    :param mutation_name: название мутации (без префикса 'mutation_')
+    :return: callable функция мутации
+    """
+    mutation_func = getattr(mutation_owner, f'mutation_{mutation_name}', None)
+    if not mutation_func:
+        raise ValueError(f'Not found mutation "{mutation_name}"')
+    return mutation_func
+
+
+def extract_mutation_kwargs(*, mutation_config: dict[str, Any]) -> dict[str, Any]:
+    """
+    Метод для получения kwargs из конфигурации мутации.
+    :param mutation_config: словарь конфигурации мутации
+    :return: словарь kwargs для передачи в функцию мутации
+    """
+    mutation_kwargs = mutation_config.get('mutation_kwargs')
+    if mutation_kwargs is None:
+        raise ValueError('mutation_kwargs is required in mutation config')
+    if not isinstance(mutation_kwargs, dict):
+        raise ValueError('mutation_kwargs must be an object (dict)')
+    return mutation_kwargs
+
+
+def run_mutation(
+    *,
+    mutation_owner: Any,
+    mutation_name: str,
+    mutation_kwargs: Optional[dict[str, Any]] = None,
+    current_value: Any = None,
+    obfuscated_values: Optional[dict[str, Any]] = None,
+) -> Any:
+    """
+    Метод для выполнения мутации с безопасным merge runtime-контекста.
+    :param mutation_owner: объект, содержащий методы mutation_<name>
+    :param mutation_name: название мутации (без префикса 'mutation_')
+    :param mutation_kwargs: параметры мутации, опционально
+    :param current_value: текущее значение поля, опционально
+    :param obfuscated_values: словарь обфусцированных значений для cross-column операций, опционально
+    :return: результат применения мутации
+    """
+    call_kwargs: dict[str, Any] = dict(mutation_kwargs or {})
+    call_kwargs.setdefault('current_value', current_value)
+    if obfuscated_values is not None:
+        call_kwargs.setdefault('obfuscated_values', obfuscated_values)
+
+    mutation_func = get_mutation_func(mutation_owner=mutation_owner, mutation_name=mutation_name)
+    return mutation_func(**call_kwargs)
+
+
+def normalize_json_current_value(value: Any) -> Any:
+    """
+    Метод для подготовки вложенного JSON-значения перед передачей в мутацию.
+    Преобразует объекты в JSON-строку, сохраняя строки и None без изменений.
+    :param value: значение для подготовки
+    :return: подготовленное значение (строка или JSON)
+    """
+    if value is None or isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=False)
+
+
+def restore_json_numeric_type(*, original_value: Any, new_value: Any) -> Any:
+    """
+    Метод для сохранения числовых типов после мутации.
+    Преобразует результат обратно в int или float, если исходное значение было числом.
+    :param original_value: исходное значение (для определения типа)
+    :param new_value: новое значение после мутации
+    :return: результат с восстановленным числовым типом
+    """
+    if isinstance(original_value, bool):
+        return new_value
+
+    if isinstance(original_value, int):
+        try:
+            return int(new_value)
+        except (TypeError, ValueError):
+            return new_value
+
+    if isinstance(original_value, float):
+        try:
+            return float(new_value)
+        except (TypeError, ValueError):
+            return new_value
+
+    return new_value
+
+
+def apply_mutations_to_json_value(
+    *,
+    mutation_owner: Any,
+    value: Any,
+    key_mutations: list[dict[str, Any]],
+    obfuscated_values: Optional[dict[str, Any]] = None,
+) -> tuple[bool, Any]:
+    """
+    Метод для применения последовательности мутаций к одному JSON-значению.
+    :param mutation_owner: объект, содержащий методы mutation_<name>
+    :param value: текущее значение ключа
+    :param key_mutations: список словарей с конфигурациями мутаций для применения подряд
+    :param obfuscated_values: словарь обфусцированных значений для cross-column операций, опционально
+    :return: кортеж (нужно_ли_удалить_ключ, новое_значение)
+    """
+    result_value = value
+    for key_mutation in key_mutations:
+        if not isinstance(key_mutation, dict):
+            raise ValueError(
+                f'Each mutation must be an object (dict), but got {type(key_mutation).__name__}'
+            )
+
+        mutation_name: str = key_mutation.get('mutation_name', '')
+        if not mutation_name:
+            raise ValueError('mutation_name not specified for json key')
+
+        if mutation_name == 'delete':
+            return True, None
+
+        if mutation_name == 'null':
+            result_value = None
+            continue
+
+        mutation_kwargs = extract_mutation_kwargs(mutation_config=key_mutation)
+        original_value = result_value
+        new_value = run_mutation(
+            mutation_owner=mutation_owner,
+            mutation_name=mutation_name,
+            mutation_kwargs=mutation_kwargs,
+            current_value=normalize_json_current_value(result_value),
+            obfuscated_values=obfuscated_values,
+        )
+        result_value = restore_json_numeric_type(original_value=original_value, new_value=new_value)
+
+    return False, result_value

--- a/tests/test_json_update_mutation.py
+++ b/tests/test_json_update_mutation.py
@@ -17,7 +17,7 @@ def mutator() -> Mutator:
 
 def test_json_update_existing_key_is_replaced(mutator: Mutator) -> None:
     """
-    Arrange: JSON с ключом `name`; мутация заменяет его через first_name
+    Arrange: JSON с ключом `name`; мутация fixed_value заменяет его на заданное значение
     Act: вызов mutation_json_update
     Assert: значение `name` изменилось, остальные ключи не тронуты
     """
@@ -34,24 +34,36 @@ def test_json_update_existing_key_is_replaced(mutator: Mutator) -> None:
     assert result['score'] == 42  # nosec
 
 
-def test_json_update_existing_key_passes_current_value(mutator: Mutator) -> None:
+def test_json_update_existing_key_passes_current_value(
+    mutator: Mutator, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """
-    Arrange: JSON с ключом `phone`; мутация fixed_value явно не передаёт current_value —
-             он должен подставиться автоматически из текущего значения ключа.
-             Проверяем через fixed_value, что call_kwargs формируется без ошибок.
+    Arrange: JSON с ключом `phone`; подменяем внутреннюю мутацию,
+             чтобы она возвращала значение на основе current_value
     Act: вызов mutation_json_update
-    Assert: ключ заменён на заданное значение (fixed_value работает корректно)
+    Assert: во внутреннюю мутацию автоматически передано текущее значение ключа
     """
     original = {'phone': '+70000000000', 'role': 'admin'}
+
+    def fake_mutation(*, current_value: str, **kwargs) -> str:
+        return f"masked:{current_value}"
+
+    monkeypatch.setattr(
+        mutator,
+        'mutation_test_echo',
+        fake_mutation,
+        raising=False,
+    )
+
     result = json.loads(
         mutator.mutation_json_update(
             current_value=json.dumps(original),
-            phone={'mutation_name': 'fixed_value', 'value': 'REDACTED'},
+            phone={'mutation_name': 'test_echo'},
         )
     )
 
-    assert result['phone'] == 'REDACTED'  # nosec
-    assert result['role'] == 'admin'  # nosec
+    assert result['phone'] == 'masked:+70000000000'
+    assert result['role'] == 'admin'
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_json_update_mutation.py
+++ b/tests/test_json_update_mutation.py
@@ -1,0 +1,267 @@
+import json
+
+import pytest
+
+from src.pg_stage.mutator import Mutator
+
+
+@pytest.fixture()
+def mutator() -> Mutator:
+    return Mutator(locale='en')
+
+
+# ---------------------------------------------------------------------------
+# Обновление существующего ключа
+# ---------------------------------------------------------------------------
+
+
+def test_json_update_existing_key_is_replaced(mutator: Mutator) -> None:
+    """
+    Arrange: JSON с ключом `name`; мутация заменяет его через first_name
+    Act: вызов mutation_json_update
+    Assert: значение `name` изменилось, остальные ключи не тронуты
+    """
+    original = {'name': 'Alice', 'score': 42}
+    result = json.loads(
+        mutator.mutation_json_update(
+            current_value=json.dumps(original),
+            name={'mutation_name': 'first_name'},
+        )
+    )
+
+    assert result['name'] != 'Alice'  # nosec
+    assert isinstance(result['name'], str) and result['name']  # nosec
+    assert result['score'] == 42  # nosec
+
+
+def test_json_update_existing_key_passes_current_value(mutator: Mutator) -> None:
+    """
+    Arrange: JSON с ключом `phone`; мутация fixed_value явно не передаёт current_value —
+             он должен подставиться автоматически из текущего значения ключа.
+             Проверяем через fixed_value, что call_kwargs формируется без ошибок.
+    Act: вызов mutation_json_update
+    Assert: ключ заменён на заданное значение (fixed_value работает корректно)
+    """
+    original = {'phone': '+70000000000', 'role': 'admin'}
+    result = json.loads(
+        mutator.mutation_json_update(
+            current_value=json.dumps(original),
+            phone={'mutation_name': 'fixed_value', 'value': 'REDACTED'},
+        )
+    )
+
+    assert result['phone'] == 'REDACTED'  # nosec
+    assert result['role'] == 'admin'  # nosec
+
+
+# ---------------------------------------------------------------------------
+# Добавление отсутствующего ключа
+# ---------------------------------------------------------------------------
+
+
+def test_json_update_missing_key_is_added(mutator: Mutator) -> None:
+    """
+    Arrange: JSON не содержит ключа `email`; мутация применяет к нему email
+    Act: вызов mutation_json_update
+    Assert: ключ `email` появился в результате
+    """
+    original = {'name': 'Bob'}
+    result = json.loads(
+        mutator.mutation_json_update(
+            current_value=json.dumps(original),
+            email={'mutation_name': 'email'},
+        )
+    )
+
+    assert 'email' in result  # nosec
+    assert '@' in result['email']  # nosec
+    assert result['name'] == 'Bob'  # nosec
+
+
+# ---------------------------------------------------------------------------
+# Удаление ключа (mutation_name: delete)
+# ---------------------------------------------------------------------------
+
+
+def test_json_update_delete_existing_key(mutator: Mutator) -> None:
+    """
+    Arrange: JSON с ключом `secret`; мутация delete
+    Act: вызов mutation_json_update
+    Assert: ключ `secret` отсутствует в результате, остальные нетронуты
+    """
+    original = {'name': 'Carol', 'secret': 'topsecret'}
+    result = json.loads(
+        mutator.mutation_json_update(
+            current_value=json.dumps(original),
+            secret={'mutation_name': 'delete'},
+        )
+    )
+
+    assert 'secret' not in result  # nosec
+    assert result['name'] == 'Carol'  # nosec
+
+
+def test_json_update_delete_missing_key_is_noop(mutator: Mutator) -> None:
+    """
+    Arrange: JSON не содержит ключа `ghost`; мутация delete
+    Act: вызов mutation_json_update
+    Assert: ошибок нет, JSON не изменился
+    """
+    original = {'name': 'Dave'}
+    result = json.loads(
+        mutator.mutation_json_update(
+            current_value=json.dumps(original),
+            ghost={'mutation_name': 'delete'},
+        )
+    )
+
+    assert result == {'name': 'Dave'}  # nosec
+
+
+# ---------------------------------------------------------------------------
+# Обнуление ключа (mutation_name: null)
+# ---------------------------------------------------------------------------
+
+
+def test_json_update_null_existing_key(mutator: Mutator) -> None:
+    """
+    Arrange: JSON с ключом `notes`; мутация null
+    Act: вызов mutation_json_update
+    Assert: значение `notes` стало JSON null (Python None)
+    """
+    original = {'name': 'Eve', 'notes': 'some private notes'}
+    result = json.loads(
+        mutator.mutation_json_update(
+            current_value=json.dumps(original),
+            notes={'mutation_name': 'null'},
+        )
+    )
+
+    assert result['notes'] is None  # nosec
+    assert result['name'] == 'Eve'  # nosec
+
+
+def test_json_update_null_missing_key_adds_null(mutator: Mutator) -> None:
+    """
+    Arrange: JSON не содержит ключа `notes`; мутация null
+    Act: вызов mutation_json_update
+    Assert: ключ `notes` добавлен со значением null
+    """
+    original = {'name': 'Frank'}
+    result = json.loads(
+        mutator.mutation_json_update(
+            current_value=json.dumps(original),
+            notes={'mutation_name': 'null'},
+        )
+    )
+
+    assert 'notes' in result  # nosec
+    assert result['notes'] is None  # nosec
+
+
+# ---------------------------------------------------------------------------
+# Некорректный / не-объектный JSON
+# ---------------------------------------------------------------------------
+
+
+def test_json_update_invalid_json_raises(mutator: Mutator) -> None:
+    """
+    Arrange: current_value — невалидная JSON-строка
+    Act: вызов mutation_json_update
+    Assert: поднимается ValueError с понятным сообщением
+    """
+    with pytest.raises(ValueError, match='Invalid JSON value'):
+        mutator.mutation_json_update(
+            current_value='not-json-at-all',
+            name={'mutation_name': 'first_name'},
+        )
+
+
+def test_json_update_json_array_raises(mutator: Mutator) -> None:
+    """
+    Arrange: current_value — JSON-массив, а не объект
+    Act: вызов mutation_json_update
+    Assert: поднимается ValueError
+    """
+    with pytest.raises(ValueError, match='json_update expects a JSON object'):
+        mutator.mutation_json_update(
+            current_value='[1, 2, 3]',
+            name={'mutation_name': 'first_name'},
+        )
+
+
+def test_json_update_json_scalar_raises(mutator: Mutator) -> None:
+    """
+    Arrange: current_value — JSON-скаляр (число)
+    Act: вызов mutation_json_update
+    Assert: поднимается ValueError
+    """
+    with pytest.raises(ValueError, match='json_update expects a JSON object'):
+        mutator.mutation_json_update(
+            current_value='42',
+            name={'mutation_name': 'first_name'},
+        )
+
+
+# ---------------------------------------------------------------------------
+# NULL-значение из БД (PostgreSQL \N)
+# ---------------------------------------------------------------------------
+
+
+def test_json_update_postgres_null_passthrough(mutator: Mutator) -> None:
+    """
+    Arrange: current_value равен PostgreSQL NULL (\\N)
+    Act: вызов mutation_json_update
+    Assert: возвращается \\N без изменений и без ошибок
+    """
+    result = mutator.mutation_json_update(
+        current_value='\\N',
+        name={'mutation_name': 'first_name'},
+    )
+
+    assert result == '\\N'  # nosec
+
+
+# ---------------------------------------------------------------------------
+# Комбинированные сценарии
+# ---------------------------------------------------------------------------
+
+
+def test_json_update_combined_operations(mutator: Mutator) -> None:
+    """
+    Arrange: JSON с несколькими ключами; одновременно замена, удаление и обнуление
+    Act: вызов mutation_json_update
+    Assert: каждая операция применена независимо и корректно
+    """
+    original = {
+        'first_name': 'Alice',
+        'secret': 'topsecret',
+        'notes': 'private',
+        'untouched': 'keep me',
+    }
+    result = json.loads(
+        mutator.mutation_json_update(
+            current_value=json.dumps(original),
+            first_name={'mutation_name': 'first_name'},
+            secret={'mutation_name': 'delete'},
+            notes={'mutation_name': 'null'},
+        )
+    )
+
+    assert result['first_name'] != 'Alice'  # nosec
+    assert 'secret' not in result  # nosec
+    assert result['notes'] is None  # nosec
+    assert result['untouched'] == 'keep me'  # nosec
+
+
+def test_json_update_unknown_mutation_raises(mutator: Mutator) -> None:
+    """
+    Arrange: mutation_kwargs указывает несуществующую мутацию
+    Act: вызов mutation_json_update
+    Assert: поднимается ValueError с именем мутации в сообщении
+    """
+    with pytest.raises(ValueError, match='Not found mutation "nonexistent"'):
+        mutator.mutation_json_update(
+            current_value='{"key": "value"}',
+            key={'mutation_name': 'nonexistent'},
+        )

--- a/tests/test_json_update_mutation.py
+++ b/tests/test_json_update_mutation.py
@@ -66,6 +66,23 @@ def test_json_update_existing_key_passes_current_value(
     assert result['role'] == 'admin'
 
 
+def test_json_update_preserving_the_numeric_type(mutator: Mutator) -> None:
+    """
+    Arrange: JSON с числовым ключом `score`
+    Act: вызов mutation mutation_numeric_integer внутри mutation_json_update
+    Assert: исходный числовой тип ключа `score` сохранится
+    """
+    original = {'score': 42}
+    result = json.loads(
+        mutator.mutation_json_update(
+            current_value=json.dumps(original),
+            score={'mutation_name': 'numeric_integer'}
+        )
+    )
+
+    assert isinstance(result['score'], int)
+
+
 # ---------------------------------------------------------------------------
 # Добавление отсутствующего ключа
 # ---------------------------------------------------------------------------

--- a/tests/test_json_update_mutation.py
+++ b/tests/test_json_update_mutation.py
@@ -212,7 +212,7 @@ def test_json_update_json_array_raises(mutator: Mutator) -> None:
     Act: вызов mutation_json_update
     Assert: поднимается ValueError
     """
-    with pytest.raises(ValueError, match='json_update expects a JSON object'):
+    with pytest.raises(ValueError, match='json_update expects a dict object'):
         mutator.mutation_json_update(
             current_value='[1, 2, 3]',
             name={'mutation_name': 'first_name'},
@@ -225,7 +225,7 @@ def test_json_update_json_scalar_raises(mutator: Mutator) -> None:
     Act: вызов mutation_json_update
     Assert: поднимается ValueError
     """
-    with pytest.raises(ValueError, match='json_update expects a JSON object'):
+    with pytest.raises(ValueError, match='json_update expects a dict object'):
         mutator.mutation_json_update(
             current_value='42',
             name={'mutation_name': 'first_name'},

--- a/tests/test_json_update_mutation.py
+++ b/tests/test_json_update_mutation.py
@@ -25,11 +25,11 @@ def test_json_update_existing_key_is_replaced(mutator: Mutator) -> None:
     result = json.loads(
         mutator.mutation_json_update(
             current_value=json.dumps(original),
-            name={'mutation_name': 'first_name'},
+            name={'mutation_name': 'fixed_value', 'value': 'John'},
         )
     )
 
-    assert result['name'] != 'Alice'  # nosec
+    assert result['name'] == 'John'  # nosec
     assert isinstance(result['name'], str) and result['name']  # nosec
     assert result['score'] == 42  # nosec
 
@@ -242,13 +242,13 @@ def test_json_update_combined_operations(mutator: Mutator) -> None:
     result = json.loads(
         mutator.mutation_json_update(
             current_value=json.dumps(original),
-            first_name={'mutation_name': 'first_name'},
+            first_name={'mutation_name': 'fixed_value', 'value': 'John'},
             secret={'mutation_name': 'delete'},
             notes={'mutation_name': 'null'},
         )
     )
 
-    assert result['first_name'] != 'Alice'  # nosec
+    assert result['first_name'] == 'John'  # nosec
     assert 'secret' not in result  # nosec
     assert result['notes'] is None  # nosec
     assert result['untouched'] == 'keep me'  # nosec

--- a/tests/test_json_update_mutation.py
+++ b/tests/test_json_update_mutation.py
@@ -25,7 +25,11 @@ def test_json_update_existing_key_is_replaced(mutator: Mutator) -> None:
     result = json.loads(
         mutator.mutation_json_update(
             current_value=json.dumps(original),
-            name={'mutation_name': 'fixed_value', 'value': 'John'},
+            mutations_by_key={
+                'name': [
+                    {'mutation_name': 'fixed_value', 'mutation_kwargs': {'value': 'John'}},
+                ]
+            },
         )
     )
 
@@ -58,7 +62,11 @@ def test_json_update_existing_key_passes_current_value(
     result = json.loads(
         mutator.mutation_json_update(
             current_value=json.dumps(original),
-            phone={'mutation_name': 'test_echo'},
+            mutations_by_key={
+                'phone': [
+                    {'mutation_name': 'test_echo', 'mutation_kwargs': {}},
+                ]
+            },
         )
     )
 
@@ -76,7 +84,11 @@ def test_json_update_preserving_the_numeric_type(mutator: Mutator) -> None:
     result = json.loads(
         mutator.mutation_json_update(
             current_value=json.dumps(original),
-            score={'mutation_name': 'numeric_integer'}
+            mutations_by_key={
+                'score': [
+                    {'mutation_name': 'numeric_integer', 'mutation_kwargs': {}},
+                ]
+            },
         )
     )
 
@@ -98,7 +110,11 @@ def test_json_update_missing_key_is_added(mutator: Mutator) -> None:
     result = json.loads(
         mutator.mutation_json_update(
             current_value=json.dumps(original),
-            email={'mutation_name': 'email'},
+            mutations_by_key={
+                'email': [
+                    {'mutation_name': 'email', 'mutation_kwargs': {}},
+                ]
+            },
         )
     )
 
@@ -122,7 +138,11 @@ def test_json_update_delete_existing_key(mutator: Mutator) -> None:
     result = json.loads(
         mutator.mutation_json_update(
             current_value=json.dumps(original),
-            secret={'mutation_name': 'delete'},
+            mutations_by_key={
+                'secret': [
+                    {'mutation_name': 'delete', 'mutation_kwargs': {}},
+                ]
+            },
         )
     )
 
@@ -140,7 +160,11 @@ def test_json_update_delete_missing_key_is_noop(mutator: Mutator) -> None:
     result = json.loads(
         mutator.mutation_json_update(
             current_value=json.dumps(original),
-            ghost={'mutation_name': 'delete'},
+            mutations_by_key={
+                'ghost': [
+                    {'mutation_name': 'delete', 'mutation_kwargs': {}},
+                ]
+            },
         )
     )
 
@@ -162,7 +186,11 @@ def test_json_update_null_existing_key(mutator: Mutator) -> None:
     result = json.loads(
         mutator.mutation_json_update(
             current_value=json.dumps(original),
-            notes={'mutation_name': 'null'},
+            mutations_by_key={
+                'notes': [
+                    {'mutation_name': 'null'},
+                ]
+            },
         )
     )
 
@@ -180,7 +208,11 @@ def test_json_update_null_missing_key_adds_null(mutator: Mutator) -> None:
     result = json.loads(
         mutator.mutation_json_update(
             current_value=json.dumps(original),
-            notes={'mutation_name': 'null'},
+            mutations_by_key={
+                'notes': [
+                    {'mutation_name': 'null', 'mutation_kwargs': {}},
+                ]
+            },
         )
     )
 
@@ -202,7 +234,7 @@ def test_json_update_invalid_json_raises(mutator: Mutator) -> None:
     with pytest.raises(ValueError, match='Invalid JSON value'):
         mutator.mutation_json_update(
             current_value='not-json-at-all',
-            name={'mutation_name': 'first_name'},
+            mutations_by_key={'name': [{'mutation_name': 'first_name', 'mutation_kwargs': {}}]},
         )
 
 
@@ -212,11 +244,13 @@ def test_json_update_json_array_raises(mutator: Mutator) -> None:
     Act: вызов mutation_json_update
     Assert: поднимается ValueError
     """
-    with pytest.raises(ValueError, match='json_update expects a dict object'):
-        mutator.mutation_json_update(
-            current_value='[1, 2, 3]',
-            name={'mutation_name': 'first_name'},
-        )
+    result = mutator.mutation_json_update(
+        current_value='[1, 2, 3]',
+        mutations_by_key={'name': [{'mutation_name': 'first_name', 'mutation_kwargs': {}}]},
+    )
+
+    # Non-dict JSON is passed through unchanged (warning logged)
+    assert result == '[1, 2, 3]'
 
 
 def test_json_update_json_scalar_raises(mutator: Mutator) -> None:
@@ -225,11 +259,13 @@ def test_json_update_json_scalar_raises(mutator: Mutator) -> None:
     Act: вызов mutation_json_update
     Assert: поднимается ValueError
     """
-    with pytest.raises(ValueError, match='json_update expects a dict object'):
-        mutator.mutation_json_update(
-            current_value='42',
-            name={'mutation_name': 'first_name'},
-        )
+    result = mutator.mutation_json_update(
+        current_value='42',
+        mutations_by_key={'name': [{'mutation_name': 'first_name', 'mutation_kwargs': {}}]},
+    )
+
+    # JSON scalar is passed through unchanged (warning logged)
+    assert result == '42'
 
 
 # ---------------------------------------------------------------------------
@@ -245,7 +281,7 @@ def test_json_update_postgres_null_passthrough(mutator: Mutator) -> None:
     """
     result = mutator.mutation_json_update(
         current_value='\\N',
-        name={'mutation_name': 'first_name'},
+        mutations_by_key={'name': [{'mutation_name': 'first_name', 'mutation_kwargs': {}}]},
     )
 
     assert result == '\\N'  # nosec
@@ -271,9 +307,17 @@ def test_json_update_combined_operations(mutator: Mutator) -> None:
     result = json.loads(
         mutator.mutation_json_update(
             current_value=json.dumps(original),
-            first_name={'mutation_name': 'fixed_value', 'value': 'John'},
-            secret={'mutation_name': 'delete'},
-            notes={'mutation_name': 'null'},
+            mutations_by_key={
+                'first_name': [
+                    {'mutation_name': 'fixed_value', 'mutation_kwargs': {'value': 'John'}},
+                ],
+                'secret': [
+                    {'mutation_name': 'delete', 'mutation_kwargs': {}},
+                ],
+                'notes': [
+                    {'mutation_name': 'null', 'mutation_kwargs': {}},
+                ],
+            },
         )
     )
 
@@ -292,5 +336,58 @@ def test_json_update_unknown_mutation_raises(mutator: Mutator) -> None:
     with pytest.raises(ValueError, match='Not found mutation "nonexistent"'):
         mutator.mutation_json_update(
             current_value='{"key": "value"}',
-            key={'mutation_name': 'nonexistent'},
+            mutations_by_key={'key': [{'mutation_name': 'nonexistent', 'mutation_kwargs': {}}]},
         )
+
+
+def test_json_update_applies_mutations_recursively(mutator: Mutator) -> None:
+    """
+    Arrange: целевой ключ находится в nested dict и в dict внутри списка.
+    Act: запускаем json_update с мутацией по имени ключа.
+    Assert: мутация применена ко всем совпавшим ключам рекурсивно.
+    """
+    original = {
+        'profile': {
+            'phone': '+70000000001',
+        },
+        'contacts': [
+            {'phone': '+70000000002'},
+            {'phone': '+70000000003'},
+        ],
+    }
+
+    result = json.loads(
+        mutator.mutation_json_update(
+            current_value=json.dumps(original),
+            mutations_by_key={
+                'phone': [
+                    {'mutation_name': 'fixed_value', 'mutation_kwargs': {'value': 'MASKED'}},
+                ]
+            },
+        )
+    )
+
+    assert result['profile']['phone'] == 'MASKED'
+    assert result['contacts'][0]['phone'] == 'MASKED'
+    assert result['contacts'][1]['phone'] == 'MASKED'
+
+
+def test_json_update_key_name_can_be_current_value(mutator: Mutator) -> None:
+    """
+    Arrange: в JSON есть ключ с именем current_value.
+    Act: применяем мутацию через mutations_by_key.
+    Assert: ключ не конфликтует со служебными параметрами вызова.
+    """
+    original = {'current_value': 'sensitive'}
+    result = json.loads(
+        mutator.mutation_json_update(
+            current_value=json.dumps(original),
+            mutations_by_key={
+                'current_value': [
+                    {'mutation_name': 'fixed_value', 'mutation_kwargs': {'value': 'safe'}},
+                ]
+            },
+        )
+    )
+
+    assert result['current_value'] == 'safe'


### PR DESCRIPTION
## issue
- https://github.com/froOzzy/pg_stage/issues/63

## description
- добавлен метод для частичного обновления jsonb поля
- принимает текущее значение поля и ```mutation_kwargs```
- вызывает соответствующий метод мутатора, зависимо от содержимого ```mutation_kwargs```
- если `mutation_name` для поля указан `delete` - поле вместе с ключом удаляется
- если `mutation_name` для поля указан `null` - ключу присваивается значение `None`, которое после json парсинга преобразовывается в `null`
- остальные методы мутатора вызываются как будто ключ - это поле в БД
---
- добавлены тесты для **нового мутатора**
- в рамках тестов работа самого обфускатора (включая парсинг коммент-строк) не проверяется, так как предполагается, что их работа проверена в других тестах
<img width="1813" height="605" alt="image" src="https://github.com/user-attachments/assets/19b0fbe7-856c-4a35-b4f9-81b4a9163fdb" />
<img width="1814" height="403" alt="image" src="https://github.com/user-attachments/assets/cc231d3a-e2e8-46f2-86a9-9d8b5fb72637" />

